### PR TITLE
Add parameter to control which module to generate code into

### DIFF
--- a/lib/yogurt/code_generator.rb
+++ b/lib/yogurt/code_generator.rb
@@ -15,9 +15,10 @@ module Yogurt
     sig {returns(T::Hash[String, DefinedClass])}
     attr_reader :classes
 
-    sig {params(schema: GRAPHQL_SCHEMA).void}
-    def initialize(schema)
+    sig {params(schema: GRAPHQL_SCHEMA, generated_code_module: Module).void}
+    def initialize(schema, generated_code_module)
       @schema = T.let(schema, GRAPHQL_SCHEMA)
+      @generated_code_module = T.let(generated_code_module, Module)
 
       # Maps GraphQL enum name to class name
       @enums = T.let({}, T::Hash[String, String])
@@ -136,8 +137,7 @@ module Yogurt
       enum_class_name = @enums[enum_type.graphql_name]
       return enum_class_name if enum_class_name
 
-      # TODO: sanitize the name
-      klass_name = "::#{schema.name}::#{enum_type.graphql_name}"
+      klass_name = "::#{@generated_code_module.name}::#{enum_type.graphql_name}"
       add_class(EnumClass.new(name: klass_name, serialized_values: enum_type.values.keys))
       @enums[enum_type.graphql_name] = klass_name
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ require 'yogurt'
 require_relative 'support/type_check'
 require_relative 'support/fake_executor'
 
+module GeneratedCode
+  # containing module for generated code
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/yogurt/code_generator_spec.rb
+++ b/spec/yogurt/code_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Yogurt::CodeGenerator do
     GRAPHQL
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
 
     classes = generator.classes
@@ -62,7 +62,7 @@ RSpec.describe Yogurt::CodeGenerator do
     GRAPHQL
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
 
     viewer_class = generator.classes["::FakeContainer::SomeQuery::Viewer"]
@@ -88,7 +88,7 @@ RSpec.describe Yogurt::CodeGenerator do
     GRAPHQL
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
 
     query_class = generator.classes["::FakeContainer::SomeQuery"]
@@ -122,7 +122,7 @@ RSpec.describe Yogurt::CodeGenerator do
     GRAPHQL
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
 
     check_run_input = generator.classes['::FakeSchema::CreateCheckRunInput']
@@ -181,7 +181,7 @@ RSpec.describe Yogurt::CodeGenerator do
     GRAPHQL
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
 
     query = generator.classes["::FakeContainer::AliasedQuery"]
@@ -230,19 +230,19 @@ RSpec.describe Yogurt::CodeGenerator do
         }
       GRAPHQL
 
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       FakeContainer.declared_queries.each {|declaration| generator.generate(declaration)}
-      expect(generator.content_files.map(&:constant_name)).to eq([
+      expect(generator.content_files.map(&:constant_name).sort).to eq([
         "::FakeContainer::AliasedQuery",
         "::FakeContainer::AliasedQuery::Me_Viewer",
-        "::FakeSchema::CheckConclusionState",
+        "::GeneratedCode::CheckConclusionState",
         "::FakeSchema::CheckRunAction",
-        "::FakeSchema::CheckAnnotationLevel",
+        "::GeneratedCode::CheckAnnotationLevel",
         "::FakeSchema::CheckAnnotationRange",
         "::FakeSchema::CheckAnnotationData",
         "::FakeSchema::CheckRunOutputImage",
         "::FakeSchema::CheckRunOutput",
-        "::FakeSchema::RequestableCheckStatusState",
+        "::GeneratedCode::RequestableCheckStatusState",
         "::FakeSchema::CreateCheckRunInput",
         "::FakeContainer::SampleMutation",
         "::FakeContainer::SampleMutation::CreateCheckRun",
@@ -250,7 +250,7 @@ RSpec.describe Yogurt::CodeGenerator do
         "::FakeContainer::SampleMutation::PinIssue",
         "::FakeContainer::SomeQuery",
         "::FakeContainer::SomeQuery::Viewer"
-      ])
+      ].sort)
     end
   end
 
@@ -265,7 +265,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       node_class = generator.classes["::FakeContainer::NodeQuery::Node"]
@@ -292,7 +292,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       node_class = generator.classes["::FakeContainer::NodeQuery::Node"]
@@ -303,18 +303,18 @@ RSpec.describe Yogurt::CodeGenerator do
       expect(state_method.branches).to match_array([
         Yogurt::CodeGenerator::FieldAccessMethod::FragmentBranch.new(
           typenames: Set.new(["Project"]),
-          expression: '::FakeSchema::ProjectState.deserialize(raw_result["state"])',
+          expression: '::GeneratedCode::ProjectState.deserialize(raw_result["state"])',
         ),
         Yogurt::CodeGenerator::FieldAccessMethod::FragmentBranch.new(
           typenames: Set.new(["ProjectCard"]),
           expression: <<~STRING.strip,
             return if raw_result["state"].nil?
-            ::FakeSchema::ProjectCardState.deserialize(raw_result["state"])
+            ::GeneratedCode::ProjectCardState.deserialize(raw_result["state"])
           STRING
         ),
         Yogurt::CodeGenerator::FieldAccessMethod::FragmentBranch.new(
           typenames: Set.new(["PullRequest"]),
-          expression: '::FakeSchema::PullRequestState.deserialize(raw_result["state"])',
+          expression: '::GeneratedCode::PullRequestState.deserialize(raw_result["state"])',
         )
       ])
 
@@ -339,7 +339,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       node_class = generator.classes["::FakeContainer::NodeQuery::Node"]
@@ -363,7 +363,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       viewer_class = generator.classes["::FakeContainer::ViewerQuery::Viewer"]
@@ -391,7 +391,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       node_class = generator.classes["::FakeContainer::NodeQuery::Node"]
@@ -424,7 +424,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       viewer_class = generator.classes["::FakeContainer::NodeQuery::Viewer"]
@@ -446,7 +446,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       viewer_class = generator.classes["::FakeContainer::NodeQuery::Viewer"]
@@ -483,20 +483,20 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       node_class = generator.classes["::FakeContainer::NodeQuery::Node"]
       field_method = node_class.defined_methods.detect {|dm| dm.name == :field}
       expect(field_method).to_not be_nil
-      expect(field_method.signature).to eq "T.nilable(T.any(::FakeContainer::NodeQuery::Node::Field_Actor, ::FakeContainer::NodeQuery::Node::Field_ProjectCard, Integer, T::Array[::FakeSchema::CommentCannotUpdateReason]))"
+      expect(field_method.signature).to eq "T.nilable(T.any(::FakeContainer::NodeQuery::Node::Field_Actor, ::FakeContainer::NodeQuery::Node::Field_ProjectCard, Integer, T::Array[::GeneratedCode::CommentCannotUpdateReason]))"
 
       expect(field_method.branches).to match_array([
         Yogurt::CodeGenerator::FieldAccessMethod::FragmentBranch.new(
           typenames: Set.new(["CommitComment"]),
           expression: <<~STRING.strip,
             raw_result["field"].map do |raw_value|
-              ::FakeSchema::CommentCannotUpdateReason.deserialize(raw_value)
+              ::GeneratedCode::CommentCannotUpdateReason.deserialize(raw_value)
             end
           STRING
         ),
@@ -559,7 +559,7 @@ RSpec.describe Yogurt::CodeGenerator do
       GRAPHQL
 
       FakeContainer.declare_query(query_text)
-      generator = Yogurt::CodeGenerator.new(FakeSchema)
+      generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
       generator.generate(FakeContainer.declared_queries[0])
 
       project_card_class = generator.classes["::FakeContainer::NodeQuery::Node::ProjectCard"]

--- a/spec/yogurt/query_execution_spec.rb
+++ b/spec/yogurt/query_execution_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "QueryResult.execute" do
     Yogurt.register_scalar(FakeSchema, "DateTime", Yogurt::Converters::Time)
 
     FakeContainer.declare_query(query_text)
-    generator = Yogurt::CodeGenerator.new(FakeSchema)
+    generator = Yogurt::CodeGenerator.new(FakeSchema, GeneratedCode)
     generator.generate(FakeContainer.declared_queries[0])
     type_check(generator.contents)
     eval(generator.contents) # rubocop:disable Security/Eval


### PR DESCRIPTION
### Motivation
Adds a new code generator parameter that controls which module the generated code will be in. This fixes a problem where it was incorrectly trying to generate code into a module with the same name as the graphql schema class:

Specifically, the graphql-client library requires the loaded schema to be assigned to a constant, e.g.:
```ruby
class MyClient
    module Queries
      extend Yogurt::QueryContainer
    end

    Schema = GraphQL::Client.load_schema("my_schema.json")
    Http = Yogurt::Http.new("https://...")
    Yogurt.add_schema(Schema, Http)
end
```

Then you need to pass that schema into Yogurt to generate code. This is how this was done before this PR:
```ruby
# define a query
query_text = <<~'GRAPHQL'
  query NodeQuery {
    node(id: "abc") {
      __typename
      ... on Project {
        state
      }
    }
  }
GRAPHQL

# declare the query that Yogurt should generate code for
MyClient::Queries.declare_query(query_text)

# generated the code
generator = Yogurt::CodeGenerator.new(MyClient::Schema)
MyClient::Queries.declared_queries.each do |query|
  generator.generate(query)
end

# ...dump the generated code into files...
```
This had a bug where it would generate an enum named `MyClient::Schema::ProjectState` but this is problematic because there is already a constant named `MyClient::Schema` which is a class (which conflicts with the generated`MyClient::Schema` module). 

### Changes
This PR adds a new parameter to the `CodeGenerator` initializer that specifies which module to generate the code into (rather than erroneously generating a code that conflicts with the schema class).

So now the schema definition and the generated schema code can be kept separate like this:
```ruby
class MyClient
    module Queries
      extend Yogurt::QueryContainer
    end

    # Define a module that generated code will use
    module GeneratedCode
    end

    # Rename to `SchemaDefinition` to keep it from conflicting with the above `GeneratedCode` module
    SchemaDefinition = GraphQL::Client.load_schema("my_schema.json")
    Http = Yogurt::Http.new("https://...")
    Yogurt.add_schema(SchemaDefinition, Http)
end

# ...define and declare the query...

# Pass the schema definition and new generated code module name
generator = Yogurt::CodeGenerator.new(MyClient::SchemaDefinition, MyClient::GeneratedCode)
MyClient::Queries.declared_queries.each do |query|
  generator.generate(query)
end
```
This process will now generate `MyClient::GeneratedCode::ProjectState` which will not conflict with `MyClient::SchemaDefinition`.

### Testing

Specs are all passing:

```
❯ rspec

Yogurt::CodeGenerator::Utils
  underscore
    converts camel case words to underscore
  indent
    properly indents strings
    properly indents strings that don't end with newlines

Yogurt::CodeGenerator
  generates code for basic queries
  handles scalar converters
  handles arrays and nullable values
  handles variables
  handles aliases
  #content_files
    generates the right output files
  fragments
    uses the typename retrieved from the server when querying interfaces
    generates a composite type if multiple return types are possible
    handles double-nested fragments
    marks a field nullable when it is impossible to access
    handles nested fragments that are used for type detection
    handles multiple paths to the same field
    does not mark a field nullable when a fragment is used against an object type
    generates composite types when multiple fields are given the same alias
    handles the same field expanded inside of multiple fragments

Yogurt::QueryContainer
  can declare queries
  raises an error if the query is invalid
  raises an error if the query doesn't provide names for the operations
  InterfacesAndUnionsHaveTypename
    raises an error if a query against an interface type doesn't include __typename
    raises an error if the __typename field is aliased
    doesn't raise an error if the interface includes __typename
    raises an error even if there is an inline fragment spread that includes __typename
    raises an error even if there is a named fragment spread that includes __typename

QueryResult.execute
  can execute queries
  can execute queries with variables
  can execute queries using scalar converters

Finished in 16.41 seconds (files took 1.03 seconds to load)
29 examples, 0 failures
```