### PR TITLE
Fix sorbet typecheck issues in generated code

### DIFF
--- a/lib/yogurt/code_generator.rb
+++ b/lib/yogurt/code_generator.rb
@@ -41,8 +41,6 @@ module Yogurt
         # typed: strict
         # frozen_string_literal: true
 
-        require 'pp'
-
         #{definitions}
       STRING
     end

--- a/lib/yogurt/code_generator/generated_file.rb
+++ b/lib/yogurt/code_generator/generated_file.rb
@@ -43,8 +43,6 @@ module Yogurt
           # typed: strict
           # frozen_string_literal: true
 
-          require 'pp'
-
           #{code}
         STRING
       end

--- a/lib/yogurt/code_generator/utils.rb
+++ b/lib/yogurt/code_generator/utils.rb
@@ -127,7 +127,7 @@ module Yogurt
         STRING
 
         <<~STRING
-          sig {override.params(p: PP::PPMethods).void}
+          sig {override.params(p: T.untyped).void}
           def pretty_print(p)
             p.object_group(self) do
               #{indent(object_group, 2).strip}


### PR DESCRIPTION
### Motivation
The generated code was resulting in typecheck errors in the pretty_print functions

### Changes
* Removed `require 'pp'` from generated output since it is redundant
* Changed `pretty_print` sig to use `T.untyped` 

### Testing
All specs are passing

```
Finished in 15.4 seconds (files took 1.05 seconds to load)
29 examples, 0 failures
```