### PR TITLE
Fix Float cast to handle integer values

### DIFF
--- a/lib/yogurt/code_generator.rb
+++ b/lib/yogurt/code_generator.rb
@@ -495,7 +495,7 @@ module Yogurt
       elsif graphql_type == GraphQL::Types::Float
         TypedOutput.new(
           signature: "Float",
-          deserializer: 'T.cast(raw_value, Float)',
+          deserializer: 'T.cast(raw_value, T.any(Integer, Float)).to_f',
         )
       elsif graphql_type == GraphQL::Types::String
         TypedOutput.new(


### PR DESCRIPTION
### Motivation
GraphQL queries that return `Float` values with a decimal are converted correctly, but round `Float` values that look like integers (e.g. `10`) cause a sorbet casting error:
```ruby
  1) QueryResult.execute can convert float values
     Failure/Error: expect(result.enterprise.billing_info.bandwidth_quota).to eq 10
     
     TypeError:
       T.cast: Expected type Float, got type Integer with value 10
       Caller: (eval):161
     # (eval):161:in `bandwidth_quota'
     # ./spec/yogurt/query_execution_spec.rb:221:in `block (2 levels) in <top (required)>'
``` 

This PR fixes the Float converter to deal with integer values.

### Changes
* Modify the Float deserializer to cast to first cast to `T.any(Integer, Float)` then use `to_f` to convert to a float

### Testing
Added a test that performs a query that returns a couple floats, one with no decimal and one with and ensures that the result is the correct float value.

All tests are passing:
```
Finished in 16.52 seconds (files took 0.89707 seconds to load)
30 examples, 0 failures
```